### PR TITLE
Add edit/delete API endpoints and admin controls

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -56,6 +56,22 @@ if ($path === '/api/materials' && $method === 'POST') {
     json_response(['message' => 'Created', 'material_id' => $pdo->lastInsertId()], 201);
 }
 
+if (preg_match('#^/api/materials/(\d+)$#', $path, $m) && $method === 'PUT') {
+    $material_id = $m[1];
+    $data = json_decode(file_get_contents('php://input'), true);
+    if (!isset($data['title'])) json_response(['error' => 'title required'], 400);
+    $stmt = $pdo->prepare('UPDATE material SET title = ? WHERE id = ?');
+    $stmt->execute([$data['title'], $material_id]);
+    json_response(['message' => 'Updated']);
+}
+
+if (preg_match('#^/api/materials/(\d+)$#', $path, $m) && $method === 'DELETE') {
+    $material_id = $m[1];
+    $stmt = $pdo->prepare('DELETE FROM material WHERE id = ?');
+    $stmt->execute([$material_id]);
+    json_response(['message' => 'Deleted']);
+}
+
 if ($path === '/api/lessons' && $method === 'POST') {
     $data = json_decode(file_get_contents('php://input'), true);
     if (!isset($data['material_id']) || !isset($data['title'])) {
@@ -64,6 +80,27 @@ if ($path === '/api/lessons' && $method === 'POST') {
     $stmt = $pdo->prepare('INSERT INTO lesson (material_id, title, description) VALUES (?,?,?)');
     $stmt->execute([$data['material_id'], $data['title'], $data['description'] ?? null]);
     json_response(['message' => 'Lesson created', 'lesson_id' => $pdo->lastInsertId()], 201);
+}
+
+if (preg_match('#^/api/lessons/(\d+)$#', $path, $m) && $method === 'PUT') {
+    $lesson_id = $m[1];
+    $data = json_decode(file_get_contents('php://input'), true);
+    if (!isset($data['title'])) json_response(['error' => 'title required'], 400);
+    $stmt = $pdo->prepare('UPDATE lesson SET material_id = ?, title = ?, description = ? WHERE id = ?');
+    $stmt->execute([
+        $data['material_id'] ?? null,
+        $data['title'],
+        $data['description'] ?? null,
+        $lesson_id
+    ]);
+    json_response(['message' => 'Lesson updated']);
+}
+
+if (preg_match('#^/api/lessons/(\d+)$#', $path, $m) && $method === 'DELETE') {
+    $lesson_id = $m[1];
+    $stmt = $pdo->prepare('DELETE FROM lesson WHERE id = ?');
+    $stmt->execute([$lesson_id]);
+    json_response(['message' => 'Lesson deleted']);
 }
 
 if ($path === '/api/lessons/by_material' && $method === 'GET') {

--- a/frontend/src/pages/AdminLessonList.tsx
+++ b/frontend/src/pages/AdminLessonList.tsx
@@ -20,6 +20,12 @@ const AdminLessonList: React.FC = () => {
       .then(data => setLessons(data));
   }, [id]);
 
+  const refresh = () => {
+    fetch(`http://localhost:5050/api/lessons/by_material?material_id=${id}`)
+      .then(res => res.json())
+      .then(data => setLessons(data));
+  };
+
   const handleCreate = () => {
     fetch("http://localhost:5050/api/lessons", {
       method: "POST",
@@ -39,6 +45,22 @@ const AdminLessonList: React.FC = () => {
       });
   };
 
+  const handleEdit = (lesson: Lesson) => {
+    const title = prompt("新しいタイトル", lesson.title);
+    if (!title) return;
+    const desc = prompt("説明", lesson.description || "") ?? lesson.description;
+    fetch(`http://localhost:5050/api/lessons/${lesson.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ material_id: Number(id), title, description: desc }),
+    }).then(refresh);
+  };
+
+  const handleDelete = (lessonId: number) => {
+    if (!window.confirm("削除しますか？")) return;
+    fetch(`http://localhost:5050/api/lessons/${lessonId}`, { method: "DELETE" }).then(refresh);
+  };
+
   return (
     <div style={{ padding: "2rem" }}>
       <h1>レッスン一覧</h1>
@@ -46,6 +68,8 @@ const AdminLessonList: React.FC = () => {
         {lessons.map(lesson => (
           <li key={lesson.id}>
             {lesson.title} - <button onClick={() => navigate(`/admin/lessons/${lesson.id}/problems`)}>問題へ</button>
+            <button onClick={() => handleEdit(lesson)} style={{ marginLeft: "0.5rem" }}>編集</button>
+            <button onClick={() => handleDelete(lesson.id)} style={{ marginLeft: "0.5rem" }}>削除</button>
           </li>
         ))}
       </ul>

--- a/frontend/src/pages/AdminMaterialList.tsx
+++ b/frontend/src/pages/AdminMaterialList.tsx
@@ -27,6 +27,29 @@ const AdminMaterialList: React.FC = () => {
       .then((data) => setMaterials(data));
   };
 
+  const refresh = () => {
+    fetch("http://localhost:5050/api/materials")
+      .then((res) => res.json())
+      .then((data) => setMaterials(data));
+  };
+
+  const handleEdit = (id: number, currentTitle: string) => {
+    const title = prompt("新しいタイトル", currentTitle);
+    if (!title) return;
+    fetch(`http://localhost:5050/api/materials/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title }),
+    }).then(refresh);
+  };
+
+  const handleDelete = (id: number) => {
+    if (!window.confirm("削除しますか？")) return;
+    fetch(`http://localhost:5050/api/materials/${id}`, {
+      method: "DELETE",
+    }).then(refresh);
+  };
+
   return (
     <div style={{ padding: "2rem" }}>
       <h1>教材一覧</h1>
@@ -42,6 +65,12 @@ const AdminMaterialList: React.FC = () => {
           <li key={m.id}>
             <button onClick={() => navigate(`/admin/materials/${m.id}/lessons`)}>
               {m.title}
+            </button>
+            <button onClick={() => handleEdit(m.id, m.title)} style={{ marginLeft: "0.5rem" }}>
+              編集
+            </button>
+            <button onClick={() => handleDelete(m.id)} style={{ marginLeft: "0.5rem" }}>
+              削除
             </button>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- implement PUT/DELETE endpoints for materials and lessons in PHP API
- update admin materials page with edit and delete buttons
- update admin lessons page with edit and delete buttons

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab7864538832f96b6c3e8e39bba3f