### PR TITLE
Add password management endpoints and frontend form

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import AdminCreateProblem from "./pages/AdminCreateProblem"
 import AdminMaterialList from "./pages/AdminMaterialList";
 import AdminLessonList from "./pages/AdminLessonList";
 import AdminRegisterUser from "./pages/AdminRegisterUser";
+import ChangePassword from "./pages/ChangePassword";
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
         <Route path="/problems/:id" element={<ProblemDetail />} />
         <Route path="/submissions" element={<SubmissionHistory />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/change-password" element={<ChangePassword />} />
         <Route path="/admin/materials" element={<AdminMaterialList />} />
         <Route path="/admin/materials/:materialId/lessons" element={<AdminLessonList />} />
         <Route path="/admin/problems/create" element={<AdminCreateProblem />} />

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -10,6 +10,7 @@ type AuthContextType = {
   user: AuthUser | null;
   login: (user: AuthUser) => void;
   logout: () => void;
+  changePassword: (oldPass: string, newPass: string) => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -30,8 +31,25 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     localStorage.removeItem("authUser");
   };
 
+  const changePassword = async (oldPass: string, newPass: string) => {
+    if (!user) throw new Error("not logged in");
+    const res = await fetch("http://localhost:5050/api/change_password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        user_id: user.id,
+        old_password: oldPass,
+        new_password: newPass,
+      }),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || "change password failed");
+    }
+  };
+
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, login, logout, changePassword }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/ChangePassword.tsx
+++ b/frontend/src/pages/ChangePassword.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { useAuth } from "../context/AuthContext";
+
+const ChangePassword: React.FC = () => {
+  const { changePassword } = useAuth();
+  const [oldPass, setOldPass] = useState("");
+  const [newPass, setNewPass] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = () => {
+    setError("");
+    setMessage("");
+    changePassword(oldPass, newPass)
+      .then(() => {
+        setMessage("パスワードを変更しました");
+        setOldPass("");
+        setNewPass("");
+      })
+      .catch((e) => setError(e.message));
+  };
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>パスワード変更</h1>
+      {message && <p>{message}</p>}
+      {error && <p style={{ color: "red" }}>{error}</p>}
+      <div style={{ marginBottom: "1rem" }}>
+        <label>現在のパスワード：</label>
+        <input
+          type="password"
+          value={oldPass}
+          onChange={(e) => setOldPass(e.target.value)}
+        />
+      </div>
+      <div style={{ marginBottom: "1rem" }}>
+        <label>新しいパスワード：</label>
+        <input
+          type="password"
+          value={newPass}
+          onChange={(e) => setNewPass(e.target.value)}
+        />
+      </div>
+      <button onClick={handleSubmit}>変更</button>
+    </div>
+  );
+};
+
+export default ChangePassword;


### PR DESCRIPTION
## Summary
- backend: add `/api/change_password` & `/api/reset_password` endpoints
- frontend context: expose `changePassword` helper
- frontend page: implement `ChangePassword` form
- register new page in router

## Testing
- `python3 -m pytest`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab78677a8832fb240857f75d8096d