### PR TITLE
Implement test case management UI and API

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -104,6 +104,35 @@ if ($path === '/api/testcases' && $method === 'POST') {
     json_response(['message' => 'Test case created', 'testcase_id' => $pdo->lastInsertId()], 201);
 }
 
+if ($path === '/api/testcases' && $method === 'GET') {
+    $problem_id = $_GET['problem_id'] ?? null;
+    if ($problem_id) {
+        $stmt = $pdo->prepare('SELECT id, problem_id, input, expected_output FROM test_case WHERE problem_id = ?');
+        $stmt->execute([$problem_id]);
+    } else {
+        $stmt = $pdo->query('SELECT id, problem_id, input, expected_output FROM test_case');
+    }
+    json_response($stmt->fetchAll(PDO::FETCH_ASSOC));
+}
+
+if (preg_match('#^/api/testcases/(\d+)$#', $path, $m) && $method === 'PUT') {
+    $id = $m[1];
+    $data = json_decode(file_get_contents('php://input'), true);
+    if (!array_key_exists('input', $data) || !array_key_exists('expected_output', $data)) {
+        json_response(['error' => 'missing fields'], 400);
+    }
+    $stmt = $pdo->prepare('UPDATE test_case SET input = ?, expected_output = ? WHERE id = ?');
+    $stmt->execute([$data['input'], $data['expected_output'], $id]);
+    json_response(['message' => 'Updated']);
+}
+
+if (preg_match('#^/api/testcases/(\d+)$#', $path, $m) && $method === 'DELETE') {
+    $id = $m[1];
+    $stmt = $pdo->prepare('DELETE FROM test_case WHERE id = ?');
+    $stmt->execute([$id]);
+    json_response(['message' => 'Deleted']);
+}
+
 if ($path === '/api/submit' && $method === 'POST') {
     $data = json_decode(file_get_contents('php://input'), true);
     if (!isset($data['user_id']) || !isset($data['problem_id']) || !isset($data['code'])) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,10 +4,11 @@ import ProblemList from "./pages/ProblemList";
 import ProblemDetail from "./pages/ProblemDetail";
 import SubmissionHistory from "./pages/SubmissionHistory";
 import Login from "./pages/Login";
-import AdminCreateProblem from "./pages/AdminCreateProblem"
+import AdminCreateProblem from "./pages/AdminCreateProblem";
 import AdminMaterialList from "./pages/AdminMaterialList";
 import AdminLessonList from "./pages/AdminLessonList";
 import AdminRegisterUser from "./pages/AdminRegisterUser";
+import AdminCreateTestCase from "./pages/AdminCreateTestCase";
 
 function App() {
   return (
@@ -21,6 +22,7 @@ function App() {
         <Route path="/admin/materials/:materialId/lessons" element={<AdminLessonList />} />
         <Route path="/admin/problems/create" element={<AdminCreateProblem />} />
         <Route path="/admin/users/register" element={<AdminRegisterUser />} />
+        <Route path="/admin/problems/:problemId/testcases" element={<AdminCreateTestCase />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/pages/AdminCreateTestCase.tsx
+++ b/frontend/src/pages/AdminCreateTestCase.tsx
@@ -1,1 +1,128 @@
-export {}
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+interface Testcase {
+  id: number;
+  problem_id: number;
+  input: string;
+  expected_output: string;
+}
+
+const AdminCreateTestCase: React.FC = () => {
+  const { problemId } = useParams<{ problemId: string }>();
+  const [testcases, setTestcases] = useState<Testcase[]>([]);
+  const [input, setInput] = useState("");
+  const [expected, setExpected] = useState("");
+
+  useEffect(() => {
+    if (!problemId) return;
+    fetch(`http://localhost:5050/api/testcases?problem_id=${problemId}`)
+      .then((res) => res.json())
+      .then((data) => setTestcases(data));
+  }, [problemId]);
+
+  const handleAdd = () => {
+    if (!problemId) return;
+    fetch("http://localhost:5050/api/testcases", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        problem_id: Number(problemId),
+        input,
+        expected_output: expected,
+      }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        setTestcases((prev) => [
+          ...prev,
+          {
+            id: data.testcase_id,
+            problem_id: Number(problemId),
+            input,
+            expected_output: expected,
+          },
+        ]);
+        setInput("");
+        setExpected("");
+      });
+  };
+
+  const handleUpdate = (tc: Testcase) => {
+    fetch(`http://localhost:5050/api/testcases/${tc.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ input: tc.input, expected_output: tc.expected_output }),
+    }).then(() => {
+      setTestcases((prev) =>
+        prev.map((t) => (t.id === tc.id ? tc : t))
+      );
+    });
+  };
+
+  const handleDelete = (id: number) => {
+    fetch(`http://localhost:5050/api/testcases/${id}`, { method: "DELETE" }).then(
+      () => {
+        setTestcases((prev) => prev.filter((t) => t.id !== id));
+      }
+    );
+  };
+
+  const updateField = (
+    id: number,
+    field: "input" | "expected_output",
+    value: string
+  ) => {
+    setTestcases((prev) =>
+      prev.map((tc) => (tc.id === id ? { ...tc, [field]: value } : tc))
+    );
+  };
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>テストケース管理</h1>
+      <div>
+        <h2>新規追加</h2>
+        <textarea
+          placeholder="入力"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <br />
+        <textarea
+          placeholder="期待出力"
+          value={expected}
+          onChange={(e) => setExpected(e.target.value)}
+        />
+        <br />
+        <button onClick={handleAdd}>追加</button>
+      </div>
+
+      <h2 style={{ marginTop: "2rem" }}>既存テストケース</h2>
+      <ul>
+        {testcases.map((tc) => (
+          <li key={tc.id} style={{ marginBottom: "1rem" }}>
+            <textarea
+              value={tc.input}
+              onChange={(e) => updateField(tc.id, "input", e.target.value)}
+            />
+            <br />
+            <textarea
+              value={tc.expected_output}
+              onChange={(e) =>
+                updateField(tc.id, "expected_output", e.target.value)
+              }
+            />
+            <br />
+            <button onClick={() => handleUpdate(tc)}>更新</button>
+            <button onClick={() => handleDelete(tc.id)} style={{ marginLeft: "0.5rem" }}>
+              削除
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AdminCreateTestCase;


### PR DESCRIPTION
## Summary
- add CRUD endpoints for `/api/testcases` in backend
- implement AdminCreateTestCase page for managing test cases
- register the page route in `App.tsx`

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab788daec832f85a7e2a43552559d