### PR TITLE
Add JWT auth to backend and frontend

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -6,6 +6,60 @@ header('Content-Type: application/json');
 $method = $_SERVER['REQUEST_METHOD'];
 $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 
+// Simple JWT utilities
+$secret = getenv('JWT_SECRET') ?: 'secretkey';
+$current_user = null;
+
+function base64url_encode(string $data): string {
+    return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+}
+
+function base64url_decode(string $data): string {
+    return base64_decode(strtr($data, '-_', '+/'));
+}
+
+function generate_jwt(array $payload, string $secret, int $exp = 3600): string {
+    $header = ['alg' => 'HS256', 'typ' => 'JWT'];
+    $payload['exp'] = time() + $exp;
+    $segments = [
+        base64url_encode(json_encode($header)),
+        base64url_encode(json_encode($payload))
+    ];
+    $signature = hash_hmac('sha256', implode('.', $segments), $secret, true);
+    $segments[] = base64url_encode($signature);
+    return implode('.', $segments);
+}
+
+function verify_jwt(string $token, string $secret) {
+    $parts = explode('.', $token);
+    if (count($parts) !== 3) return false;
+    list($h64, $p64, $s64) = $parts;
+    $payload = json_decode(base64url_decode($p64), true);
+    if (!$payload || ($payload['exp'] ?? 0) < time()) return false;
+    $sig = base64url_decode($s64);
+    $valid = hash_hmac('sha256', "$h64.$p64", $secret, true);
+    if (!hash_equals($valid, $sig)) return false;
+    return $payload;
+}
+
+function require_auth() {
+    global $secret, $current_user;
+    $auth = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+    if (preg_match('/Bearer\s+(.*)/', $auth, $m)) {
+        $payload = verify_jwt($m[1], $secret);
+        if ($payload) {
+            $current_user = $payload;
+            return;
+        }
+    }
+    json_response(['error' => 'Unauthorized'], 401);
+}
+
+$public_paths = ['/api/login', '/api/register'];
+if (!in_array($path, $public_paths)) {
+    require_auth();
+}
+
 function json_response($data, $status = 200) {
     http_response_code($status);
     echo json_encode($data);
@@ -40,7 +94,13 @@ if ($path === '/api/login' && $method === 'POST') {
     if (!$user || !password_verify($data['password'], $user['password_hash'])) {
         json_response(['error' => 'invalid credentials'], 401);
     }
-    json_response(['message' => 'Logged in', 'user_id' => $user['id'], 'is_admin' => (int)$user['is_admin']]);
+    $token = generate_jwt(['id' => $user['id'], 'username' => $data['username'], 'is_admin' => (int)$user['is_admin']], $secret);
+    json_response([
+        'message' => 'Logged in',
+        'token' => $token,
+        'user_id' => $user['id'],
+        'is_admin' => (int)$user['is_admin']
+    ]);
 }
 
 if ($path === '/api/materials' && $method === 'GET') {
@@ -105,10 +165,12 @@ if ($path === '/api/testcases' && $method === 'POST') {
 }
 
 if ($path === '/api/submit' && $method === 'POST') {
+    global $current_user;
     $data = json_decode(file_get_contents('php://input'), true);
-    if (!isset($data['user_id']) || !isset($data['problem_id']) || !isset($data['code'])) {
+    if (!isset($data['problem_id']) || !isset($data['code'])) {
         json_response(['error' => 'missing fields'], 400);
     }
+    $data['user_id'] = $current_user['id'];
     $stmt = $pdo->prepare('SELECT input, expected_output FROM test_case WHERE problem_id = ?');
     $stmt->execute([$data['problem_id']]);
     $cases = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -147,7 +209,11 @@ if ($path === '/api/submit' && $method === 'POST') {
 }
 
 if (preg_match('#^/api/submissions/(\d+)$#', $path, $m) && $method === 'GET') {
+    global $current_user;
     $user_id = $m[1];
+    if ($current_user['id'] != $user_id && empty($current_user['is_admin'])) {
+        json_response(['error' => 'forbidden'], 403);
+    }
     $stmt = $pdo->prepare('SELECT id, problem_id, result, output, submitted_at FROM submission WHERE user_id = ? ORDER BY submitted_at DESC');
     $stmt->execute([$user_id]);
     json_response($stmt->fetchAll(PDO::FETCH_ASSOC));

--- a/frontend/src/pages/AdminCreateProblem.tsx
+++ b/frontend/src/pages/AdminCreateProblem.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useAuth } from "../context/AuthContext";
 
 type Lesson = {
   id: number;
@@ -8,9 +9,10 @@ type Lesson = {
 const AdminCreateProblem = () => {
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [selectedLessonId, setSelectedLessonId] = useState<number | null>(null);
+  const { authFetch } = useAuth();
 
   useEffect(() => {
-    fetch("http://localhost:5050/api/lessons")
+    authFetch("http://localhost:5050/api/lessons")
       .then((res) => res.json())
       .then((data) => setLessons(data));
   }, []);
@@ -18,7 +20,7 @@ const AdminCreateProblem = () => {
   const handleCreateProblem = () => {
     if (!selectedLessonId) return;
 
-    fetch("http://localhost:5050/api/problems", {
+    authFetch("http://localhost:5050/api/problems", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/frontend/src/pages/AdminLessonList.tsx
+++ b/frontend/src/pages/AdminLessonList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
 interface Lesson {
   id: number;
@@ -13,15 +14,16 @@ const AdminLessonList: React.FC = () => {
   const [newTitle, setNewTitle] = useState("");
   const [description, setDescription] = useState("");
   const navigate = useNavigate();
+  const { authFetch } = useAuth();
 
   useEffect(() => {
-    fetch(`http://localhost:5050/api/lessons/by_material?material_id=${id}`)
+    authFetch(`http://localhost:5050/api/lessons/by_material?material_id=${id}`)
       .then(res => res.json())
       .then(data => setLessons(data));
   }, [id]);
 
   const handleCreate = () => {
-    fetch("http://localhost:5050/api/lessons", {
+    authFetch("http://localhost:5050/api/lessons", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/frontend/src/pages/AdminMaterialList.tsx
+++ b/frontend/src/pages/AdminMaterialList.tsx
@@ -1,19 +1,21 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
 const AdminMaterialList: React.FC = () => {
   const [materials, setMaterials] = useState([]);
   const [newTitle, setNewTitle] = useState("");
   const navigate = useNavigate();
+  const { authFetch } = useAuth();
 
   useEffect(() => {
-    fetch("http://localhost:5050/api/materials")
+    authFetch("http://localhost:5050/api/materials")
       .then((res) => res.json())
       .then((data) => setMaterials(data));
   }, []);
 
   const handleCreate = () => {
-    fetch("http://localhost:5050/api/materials", {
+    authFetch("http://localhost:5050/api/materials", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title: newTitle }),
@@ -21,7 +23,7 @@ const AdminMaterialList: React.FC = () => {
       .then((res) => res.json())
       .then(() => {
         setNewTitle("");
-        return fetch("http://localhost:5050/api/materials");
+        return authFetch("http://localhost:5050/api/materials");
       })
       .then((res) => res.json())
       .then((data) => setMaterials(data));

--- a/frontend/src/pages/AdminRegisterUser.tsx
+++ b/frontend/src/pages/AdminRegisterUser.tsx
@@ -1,13 +1,15 @@
 import React, { useState } from "react";
+import { useAuth } from "../context/AuthContext";
 
 const AdminRegisterUser: React.FC = () => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [isAdmin, setIsAdmin] = useState(false);
   const [message, setMessage] = useState("");
+  const { authFetch } = useAuth();
 
   const handleRegister = () => {
-    fetch("http://localhost:5050/api/register", {
+    authFetch("http://localhost:5050/api/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password, is_admin: isAdmin }),

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -21,11 +21,14 @@ const Login: React.FC = () => {
         return res.json();
       })
       .then((data) => {
-        login({
-          id: data.user_id,
-          username: username,
-          is_admin: data.is_admin || false, 
-        });
+        login(
+          {
+            id: data.user_id,
+            username: username,
+            is_admin: data.is_admin || false,
+          },
+          data.token
+        );
         navigate("/"); // ログイン成功後にホームへリダイレクト
       })
       .catch(() => {

--- a/frontend/src/pages/ProblemDetail.tsx
+++ b/frontend/src/pages/ProblemDetail.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 import ReactMarkdown from "react-markdown";
 import CodeEditor from "../components/CodeEditor";
 
@@ -13,12 +14,13 @@ type Problem = {
 
 const ProblemDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const { authFetch } = useAuth();
   const [problem, setProblem] = useState<Problem | null>(null);
   const [code, setCode] = useState<string>("# Pythonのコードをここに書いてください");
   const [result, setResult] = useState<string>("");
 
   useEffect(() => {
-    fetch("http://localhost:5050/api/problems")
+    authFetch("http://localhost:5050/api/problems")
       .then((res) => res.json())
       .then((data) => {
         const found = data.find((p: Problem) => p.id === Number(id));
@@ -27,11 +29,10 @@ const ProblemDetail: React.FC = () => {
   }, [id]);
 
   const handleSubmit = () => {
-    fetch("http://localhost:5050/api/submit", {
+    authFetch("http://localhost:5050/api/submit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        user_id: 1,
         problem_id: Number(id),
         code: code,
       }),

--- a/frontend/src/pages/ProblemList.tsx
+++ b/frontend/src/pages/ProblemList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 import ReactMarkdown from "react-markdown";
 
 type Problem = {
@@ -12,9 +13,10 @@ type Problem = {
 
 const ProblemList: React.FC = () => {
   const [problems, setProblems] = useState<Problem[]>([]);
+  const { authFetch } = useAuth();
 
   useEffect(() => {
-    fetch("http://localhost:5050/api/problems")
+    authFetch("http://localhost:5050/api/problems")
       .then((res) => res.json())
       .then((data) => setProblems(data))
       .catch((err) => console.error("問題の取得に失敗しました:", err));

--- a/frontend/src/pages/SubmissionHistory.tsx
+++ b/frontend/src/pages/SubmissionHistory.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useAuth } from "../context/AuthContext";
 
 type Submission = {
   id: number;
@@ -11,9 +12,11 @@ type Submission = {
 const SubmissionHistory: React.FC = () => {
   const [submissions, setSubmissions] = useState<Submission[]>([]);
   const [loading, setLoading] = useState(true);
+  const { user, authFetch } = useAuth();
 
   useEffect(() => {
-    fetch("http://localhost:5050/api/submissions/1")
+    if (!user) return;
+    authFetch(`http://localhost:5050/api/submissions/${user.id}`)
       .then((res) => res.json())
       .then((data) => {
         setSubmissions(data);
@@ -23,7 +26,7 @@ const SubmissionHistory: React.FC = () => {
         console.error("履歴取得に失敗しました", err);
         setLoading(false);
       });
-  }, []);
+  }, [user]);
 
   return (
     <div style={{ padding: "2rem" }}>


### PR DESCRIPTION
## Summary
- generate and verify JWT tokens in PHP backend
- store auth token in React context and send automatically
- require auth for API calls and protect submissions
- adapt frontend pages to use `authFetch`

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab789ad84832fb0054316b5032c82