### PR TITLE
Refactor assignments schema and flow

### DIFF
--- a/backend/create_tables.php
+++ b/backend/create_tables.php
@@ -23,15 +23,6 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS lesson (
     FOREIGN KEY(material_id) REFERENCES material(id) ON DELETE CASCADE
 );");
 
-$pdo->exec("CREATE TABLE IF NOT EXISTS problem (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    lesson_id INTEGER NOT NULL,
-    title TEXT NOT NULL,
-    markdown TEXT,
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY(lesson_id) REFERENCES lesson(id) ON DELETE CASCADE
-);");
-
 $pdo->exec("CREATE TABLE IF NOT EXISTS assignment (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     lesson_id INTEGER NOT NULL,
@@ -46,22 +37,23 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS assignment (
 
 $pdo->exec("CREATE TABLE IF NOT EXISTS test_case (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    problem_id INTEGER NOT NULL,
+    assignment_id INTEGER NOT NULL,
     input TEXT,
     expected_output TEXT,
-    FOREIGN KEY(problem_id) REFERENCES problem(id) ON DELETE CASCADE
+    comment TEXT,
+    FOREIGN KEY(assignment_id) REFERENCES assignment(id) ON DELETE CASCADE
 );");
 
 $pdo->exec("CREATE TABLE IF NOT EXISTS submission (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER NOT NULL,
-    problem_id INTEGER NOT NULL,
+    assignment_id INTEGER NOT NULL,
     code TEXT,
-    result TEXT,
-    output TEXT,
+    is_correct INTEGER,
+    feedback TEXT,
     submitted_at TEXT DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY(user_id) REFERENCES user(id) ON DELETE CASCADE,
-    FOREIGN KEY(problem_id) REFERENCES problem(id) ON DELETE CASCADE
+    FOREIGN KEY(assignment_id) REFERENCES assignment(id) ON DELETE CASCADE
 );");
 
 $adminHash = password_hash('admin', PASSWORD_DEFAULT);

--- a/backend/index.php
+++ b/backend/index.php
@@ -204,20 +204,6 @@ if ($path === '/api/lessons' && $method === 'GET') {
     json_response($stmt->fetchAll(PDO::FETCH_ASSOC));
 }
 
-if ($path === '/api/problems' && $method === 'GET') {
-    $stmt = $pdo->query('SELECT id, lesson_id, title, markdown, created_at FROM problem');
-    json_response($stmt->fetchAll(PDO::FETCH_ASSOC));
-}
-
-if ($path === '/api/problems' && $method === 'POST') {
-    $data = json_decode(file_get_contents('php://input'), true);
-    if (!isset($data['title']) || !isset($data['markdown']) || !isset($data['lesson_id'])) {
-        json_response(['error' => 'missing fields'], 400);
-    }
-    $stmt = $pdo->prepare('INSERT INTO problem (lesson_id, title, markdown, created_at) VALUES (?,?,?,datetime("now"))');
-    $stmt->execute([$data['lesson_id'], $data['title'], $data['markdown']]);
-    json_response(['message' => 'Problem created', 'problem_id' => $pdo->lastInsertId()], 201);
-}
 
 if ($path === '/api/assignments' && $method === 'GET') {
     $stmt = $pdo->query('SELECT id, lesson_id, title, description, question_text, input_example, file_path, created_at FROM assignment');
@@ -279,21 +265,21 @@ if (preg_match('#^/api/assignments/(\d+)$#', $path, $m) && $method === 'DELETE')
 
 if ($path === '/api/testcases' && $method === 'POST') {
     $data = json_decode(file_get_contents('php://input'), true);
-    if (!isset($data['problem_id']) || !array_key_exists('input', $data) || !array_key_exists('expected_output', $data)) {
+    if (!isset($data['assignment_id']) || !array_key_exists('input', $data) || !array_key_exists('expected_output', $data)) {
         json_response(['error' => 'missing fields'], 400);
     }
-    $stmt = $pdo->prepare('INSERT INTO test_case (problem_id, input, expected_output) VALUES (?,?,?)');
-    $stmt->execute([$data['problem_id'], $data['input'], $data['expected_output']]);
+    $stmt = $pdo->prepare('INSERT INTO test_case (assignment_id, input, expected_output, comment) VALUES (?,?,?,?)');
+    $stmt->execute([$data['assignment_id'], $data['input'], $data['expected_output'], $data['comment'] ?? null]);
     json_response(['message' => 'Test case created', 'testcase_id' => $pdo->lastInsertId()], 201);
 }
 
 if ($path === '/api/testcases' && $method === 'GET') {
-    $problem_id = $_GET['problem_id'] ?? null;
-    if ($problem_id) {
-        $stmt = $pdo->prepare('SELECT id, problem_id, input, expected_output FROM test_case WHERE problem_id = ?');
-        $stmt->execute([$problem_id]);
+    $assignment_id = $_GET['assignment_id'] ?? null;
+    if ($assignment_id) {
+        $stmt = $pdo->prepare('SELECT id, assignment_id, input, expected_output, comment FROM test_case WHERE assignment_id = ?');
+        $stmt->execute([$assignment_id]);
     } else {
-        $stmt = $pdo->query('SELECT id, problem_id, input, expected_output FROM test_case');
+        $stmt = $pdo->query('SELECT id, assignment_id, input, expected_output, comment FROM test_case');
     }
     json_response($stmt->fetchAll(PDO::FETCH_ASSOC));
 }
@@ -304,8 +290,8 @@ if (preg_match('#^/api/testcases/(\d+)$#', $path, $m) && $method === 'PUT') {
     if (!array_key_exists('input', $data) || !array_key_exists('expected_output', $data)) {
         json_response(['error' => 'missing fields'], 400);
     }
-    $stmt = $pdo->prepare('UPDATE test_case SET input = ?, expected_output = ? WHERE id = ?');
-    $stmt->execute([$data['input'], $data['expected_output'], $id]);
+    $stmt = $pdo->prepare('UPDATE test_case SET input = ?, expected_output = ?, comment = COALESCE(?, comment) WHERE id = ?');
+    $stmt->execute([$data['input'], $data['expected_output'], $data['comment'] ?? null, $id]);
     json_response(['message' => 'Updated']);
 }
 
@@ -319,12 +305,12 @@ if (preg_match('#^/api/testcases/(\d+)$#', $path, $m) && $method === 'DELETE') {
 if ($path === '/api/submit' && $method === 'POST') {
     global $current_user;
     $data = json_decode(file_get_contents('php://input'), true);
-    if (!isset($data['problem_id']) || !isset($data['code'])) {
+    if (!isset($data['assignment_id']) || !isset($data['code'])) {
         json_response(['error' => 'missing fields'], 400);
     }
     $data['user_id'] = $current_user['id'];
-    $stmt = $pdo->prepare('SELECT input, expected_output FROM test_case WHERE problem_id = ?');
-    $stmt->execute([$data['problem_id']]);
+    $stmt = $pdo->prepare('SELECT input, expected_output FROM test_case WHERE assignment_id = ?');
+    $stmt->execute([$data['assignment_id']]);
     $cases = $stmt->fetchAll(PDO::FETCH_ASSOC);
     if (!$cases) json_response(['error' => 'No test cases'], 404);
 
@@ -348,16 +334,16 @@ if ($path === '/api/submit' && $method === 'POST') {
         if (!$all_passed) break;
     }
 
-    $stmt = $pdo->prepare('INSERT INTO submission (user_id, problem_id, code, result, output, submitted_at) VALUES (?,?,?,?,?,datetime("now"))');
+    $stmt = $pdo->prepare('INSERT INTO submission (user_id, assignment_id, code, is_correct, feedback, submitted_at) VALUES (?,?,?,?,?,datetime("now"))');
     $stmt->execute([
         $data['user_id'],
-        $data['problem_id'],
+        $data['assignment_id'],
         $data['code'],
-        $all_passed ? 'AC' : 'WA',
+        $all_passed ? 1 : 0,
         $all_passed ? 'All test cases passed.' : $output
     ]);
 
-    json_response(['message' => 'Submission processed', 'result' => $all_passed ? 'AC' : 'WA', 'output' => $all_passed ? 'All test cases passed.' : $output]);
+    json_response(['message' => 'Submission processed', 'is_correct' => $all_passed ? 1 : 0, 'feedback' => $all_passed ? 'All test cases passed.' : $output]);
 }
 
 if (preg_match('#^/api/submissions/(\d+)$#', $path, $m) && $method === 'GET') {
@@ -366,7 +352,7 @@ if (preg_match('#^/api/submissions/(\d+)$#', $path, $m) && $method === 'GET') {
     if ($current_user['id'] != $user_id && empty($current_user['is_admin'])) {
         json_response(['error' => 'forbidden'], 403);
     }
-    $stmt = $pdo->prepare('SELECT id, problem_id, result, output, submitted_at FROM submission WHERE user_id = ? ORDER BY submitted_at DESC');
+    $stmt = $pdo->prepare('SELECT id, assignment_id, is_correct, feedback, submitted_at FROM submission WHERE user_id = ? ORDER BY submitted_at DESC');
     $stmt->execute([$user_id]);
     json_response($stmt->fetchAll(PDO::FETCH_ASSOC));
 }
@@ -379,28 +365,28 @@ if ($path === '/api/progress' && $method === 'GET') {
         $totalStmt->execute([$user_id]);
         $totalSub = (int)$totalStmt->fetchColumn();
 
-        $correctStmt = $pdo->prepare("SELECT COUNT(*) FROM submission WHERE user_id = ? AND result = 'AC'");
+        $correctStmt = $pdo->prepare('SELECT COUNT(*) FROM submission WHERE user_id = ? AND is_correct = 1');
         $correctStmt->execute([$user_id]);
         $correct = (int)$correctStmt->fetchColumn();
 
-        $attemptedStmt = $pdo->prepare('SELECT COUNT(DISTINCT problem_id) FROM submission WHERE user_id = ?');
+        $attemptedStmt = $pdo->prepare('SELECT COUNT(DISTINCT assignment_id) FROM submission WHERE user_id = ?');
         $attemptedStmt->execute([$user_id]);
         $attempted = (int)$attemptedStmt->fetchColumn();
     } else {
         $totalStmt = $pdo->query('SELECT COUNT(*) FROM submission');
         $totalSub = (int)$totalStmt->fetchColumn();
 
-        $correctStmt = $pdo->query("SELECT COUNT(*) FROM submission WHERE result = 'AC'");
+        $correctStmt = $pdo->query('SELECT COUNT(*) FROM submission WHERE is_correct = 1');
         $correct = (int)$correctStmt->fetchColumn();
 
-        $attemptedStmt = $pdo->query('SELECT COUNT(DISTINCT problem_id) FROM submission');
+        $attemptedStmt = $pdo->query('SELECT COUNT(DISTINCT assignment_id) FROM submission');
         $attempted = (int)$attemptedStmt->fetchColumn();
     }
 
     $incorrect = $totalSub - $correct;
-    $totalProblemStmt = $pdo->query('SELECT COUNT(*) FROM problem');
-    $totalProblems = (int)$totalProblemStmt->fetchColumn();
-    $unsubmitted = $totalProblems - $attempted;
+    $totalStmtAll = $pdo->query('SELECT COUNT(*) FROM assignment');
+    $totalAssignments = (int)$totalStmtAll->fetchColumn();
+    $unsubmitted = $totalAssignments - $attempted;
 
     if ($user_id) {
         $dailyStmt = $pdo->prepare('SELECT substr(submitted_at,1,10) as date, COUNT(*) as count FROM submission WHERE user_id = ? GROUP BY substr(submitted_at,1,10)');
@@ -413,19 +399,19 @@ if ($path === '/api/progress' && $method === 'GET') {
     $materials = [];
     $matStmt = $pdo->query('SELECT id, title FROM material');
     foreach ($matStmt as $m) {
-        $totalP = $pdo->prepare('SELECT COUNT(*) FROM problem JOIN lesson ON problem.lesson_id = lesson.id WHERE lesson.material_id = ?');
+        $totalP = $pdo->prepare('SELECT COUNT(*) FROM assignment JOIN lesson ON assignment.lesson_id = lesson.id WHERE lesson.material_id = ?');
         $totalP->execute([$m['id']]);
         $total = (int)$totalP->fetchColumn();
 
         if ($user_id) {
-            $compStmt = $pdo->prepare('SELECT COUNT(DISTINCT problem.id) FROM problem JOIN lesson ON problem.lesson_id = lesson.id JOIN submission s ON s.problem_id = problem.id WHERE s.user_id = ? AND s.result = "AC" AND lesson.material_id = ?');
+            $compStmt = $pdo->prepare('SELECT COUNT(DISTINCT assignment.id) FROM assignment JOIN lesson ON assignment.lesson_id = lesson.id JOIN submission s ON s.assignment_id = assignment.id WHERE s.user_id = ? AND s.is_correct = 1 AND lesson.material_id = ?');
             $compStmt->execute([$user_id, $m['id']]);
         } else {
-            $compStmt = $pdo->prepare('SELECT COUNT(DISTINCT problem.id) FROM problem JOIN lesson ON problem.lesson_id = lesson.id JOIN submission s ON s.problem_id = problem.id WHERE s.result = "AC" AND lesson.material_id = ?');
+            $compStmt = $pdo->prepare('SELECT COUNT(DISTINCT assignment.id) FROM assignment JOIN lesson ON assignment.lesson_id = lesson.id JOIN submission s ON s.assignment_id = assignment.id WHERE s.is_correct = 1 AND lesson.material_id = ?');
             $compStmt->execute([$m['id']]);
         }
         $completed = (int)$compStmt->fetchColumn();
-
+        
         $materials[] = [
             'material_id' => (int)$m['id'],
             'title' => $m['title'],
@@ -435,7 +421,7 @@ if ($path === '/api/progress' && $method === 'GET') {
     }
 
     json_response([
-        'total_problems' => $totalProblems,
+        'total_assignments' => $totalAssignments,
         'correct' => $correct,
         'incorrect' => $incorrect,
         'unsubmitted' => $unsubmitted,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,6 @@ import ProblemList from "./pages/ProblemList";
 import ProblemDetail from "./pages/ProblemDetail";
 import SubmissionHistory from "./pages/SubmissionHistory";
 import Login from "./pages/Login";
-import AdminCreateProblem from "./pages/AdminCreateProblem";
 import AdminMaterialList from "./pages/AdminMaterialList";
 import AdminLessonList from "./pages/AdminLessonList";
 import AdminRegisterUser from "./pages/AdminRegisterUser";
@@ -19,7 +18,7 @@ function App() {
     <Router>
       <Routes>
         <Route path="/" element={<ProblemList />} />
-        <Route path="/problems/:id" element={<ProblemDetail />} />
+        <Route path="/assignments/:id" element={<ProblemDetail />} />
         <Route path="/submissions" element={<SubmissionHistory />} />
         <Route path="/dashboard" element={<StudentDashboard />} />
         <Route path="/admin/dashboard" element={<AdminDashboard />} />
@@ -29,7 +28,6 @@ function App() {
         <Route path="/change-password" element={<ChangePassword />} />
         <Route path="/admin/materials" element={<AdminMaterialList />} />
         <Route path="/admin/materials/:materialId/lessons" element={<AdminLessonList />} />
-        <Route path="/admin/problems/create" element={<AdminCreateProblem />} />
         <Route path="/admin/users/register" element={<AdminRegisterUser />} />
       </Routes>
     </Router>

--- a/frontend/src/pages/AdminCreateAssignment.tsx
+++ b/frontend/src/pages/AdminCreateAssignment.tsx
@@ -4,7 +4,9 @@ interface Lesson { id: number; title: string; }
 
 const AdminCreateAssignment: React.FC = () => {
   const [lessons, setLessons] = useState<Lesson[]>([]);
-  const [lessonId, setLessonId] = useState<number | "">("");
+  const params = new URLSearchParams(window.location.search);
+  const initialLesson = params.get("lesson_id");
+  const [lessonId, setLessonId] = useState<number | "">(initialLesson ? Number(initialLesson) : "");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [questionText, setQuestionText] = useState("");

--- a/frontend/src/pages/AdminCreateTestCase.tsx
+++ b/frontend/src/pages/AdminCreateTestCase.tsx
@@ -3,31 +3,32 @@ import { useParams } from "react-router-dom";
 
 interface Testcase {
   id: number;
-  problem_id: number;
+  assignment_id: number;
   input: string;
   expected_output: string;
+  comment?: string;
 }
 
 const AdminCreateTestCase: React.FC = () => {
-  const { problemId } = useParams<{ problemId: string }>();
+  const { assignmentId } = useParams<{ assignmentId: string }>();
   const [testcases, setTestcases] = useState<Testcase[]>([]);
   const [input, setInput] = useState("");
   const [expected, setExpected] = useState("");
 
   useEffect(() => {
-    if (!problemId) return;
-    fetch(`http://localhost:5050/api/testcases?problem_id=${problemId}`)
+    if (!assignmentId) return;
+    fetch(`http://localhost:5050/api/testcases?assignment_id=${assignmentId}`)
       .then((res) => res.json())
       .then((data) => setTestcases(data));
-  }, [problemId]);
+  }, [assignmentId]);
 
   const handleAdd = () => {
-    if (!problemId) return;
+    if (!assignmentId) return;
     fetch("http://localhost:5050/api/testcases", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        problem_id: Number(problemId),
+        assignment_id: Number(assignmentId),
         input,
         expected_output: expected,
       }),
@@ -38,7 +39,7 @@ const AdminCreateTestCase: React.FC = () => {
           ...prev,
           {
             id: data.testcase_id,
-            problem_id: Number(problemId),
+            assignment_id: Number(assignmentId),
             input,
             expected_output: expected,
           },

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -14,7 +14,7 @@ interface MaterialProgress {
 }
 
 interface ProgressData {
-  total_problems: number;
+  total_assignments: number;
   correct: number;
   incorrect: number;
   unsubmitted: number;

--- a/frontend/src/pages/AdminLessonList.tsx
+++ b/frontend/src/pages/AdminLessonList.tsx
@@ -69,7 +69,7 @@ const AdminLessonList: React.FC = () => {
       <ul>
         {lessons.map(lesson => (
           <li key={lesson.id}>
-            {lesson.title} - <button onClick={() => navigate(`/admin/lessons/${lesson.id}/problems`)}>問題へ</button>
+            {lesson.title} - <button onClick={() => navigate(`/admin/assignments/create?lesson_id=${lesson.id}`)}>宿題作成</button>
             <button onClick={() => handleEdit(lesson)} style={{ marginLeft: "0.5rem" }}>編集</button>
             <button onClick={() => handleDelete(lesson.id)} style={{ marginLeft: "0.5rem" }}>削除</button>
           </li>

--- a/frontend/src/pages/ProblemDetail.tsx
+++ b/frontend/src/pages/ProblemDetail.tsx
@@ -1,31 +1,29 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
-import ReactMarkdown from "react-markdown";
 import CodeEditor from "../components/CodeEditor";
 
-type Problem = {
+type Assignment = {
   id: number;
   lesson_id: number;
   title: string;
-  markdown: string;
-  created_at: string;
+  description: string;
+  question_text: string;
+  input_example: string;
+  file_path: string | null;
 };
 
 const ProblemDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { authFetch } = useAuth();
-  const [problem, setProblem] = useState<Problem | null>(null);
+  const [assignment, setAssignment] = useState<Assignment | null>(null);
   const [code, setCode] = useState<string>("# Pythonのコードをここに書いてください");
   const [result, setResult] = useState<string>("");
 
   useEffect(() => {
-    authFetch("http://localhost:5050/api/problems")
+    authFetch(`http://localhost:5050/api/assignments/${id}`)
       .then((res) => res.json())
-      .then((data) => {
-        const found = data.find((p: Problem) => p.id === Number(id));
-        setProblem(found);
-      });
+      .then((data) => setAssignment(data));
   }, [id]);
 
   const handleSubmit = () => {
@@ -33,22 +31,22 @@ const ProblemDetail: React.FC = () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        problem_id: Number(id),
+        assignment_id: Number(id),
         code: code,
       }),
     })
       .then((res) => res.json())
       .then((data) => {
-        setResult(`結果: ${data.result}\n出力: ${data.output}`);
+        setResult(`結果: ${data.is_correct ? "AC" : "WA"}\n${data.feedback}`);
       });
   };
 
-  if (!problem) return <p>読み込み中...</p>;
+  if (!assignment) return <p>読み込み中...</p>;
 
   return (
     <div style={{ padding: "2rem" }}>
-      <h1>{problem.title}</h1>
-      <ReactMarkdown>{problem.markdown}</ReactMarkdown>
+      <h1>{assignment.title}</h1>
+      <p>{assignment.question_text}</p>
 
       <CodeEditor value={code} onChange={setCode} />
 

--- a/frontend/src/pages/ProblemList.tsx
+++ b/frontend/src/pages/ProblemList.tsx
@@ -3,36 +3,38 @@ import { Link } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import ReactMarkdown from "react-markdown";
 
-type Problem = {
+type Assignment = {
   id: number;
   lesson_id: number;
   title: string;
-  markdown: string;
-  created_at: string;
+  description: string;
+  question_text: string;
+  input_example: string;
+  file_path: string | null;
 };
 
 const ProblemList: React.FC = () => {
-  const [problems, setProblems] = useState<Problem[]>([]);
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
   const { authFetch } = useAuth();
 
   useEffect(() => {
-    authFetch("http://localhost:5050/api/problems")
+    authFetch("http://localhost:5050/api/assignments")
       .then((res) => res.json())
-      .then((data) => setProblems(data))
-      .catch((err) => console.error("問題の取得に失敗しました:", err));
+      .then((data) => setAssignments(data))
+      .catch((err) => console.error("宿題の取得に失敗しました:", err));
   }, []);
 
   return (
     <div style={{ padding: "2rem" }}>
-      <h1>Python問題一覧</h1>
+      <h1>宿題一覧</h1>
       <ul>
-        {problems.map((problem) => (
-          <li key={problem.id} style={{ marginBottom: "2rem" }}>
-            <Link to={`/problems/${problem.id}`}>
-              <h2>{problem.title}</h2>
+        {assignments.map((a) => (
+          <li key={a.id} style={{ marginBottom: "2rem" }}>
+            <Link to={`/assignments/${a.id}`}>
+              <h2>{a.title}</h2>
             </Link>
-            <ReactMarkdown>{problem.markdown}</ReactMarkdown>
-            <p>問題ID: {problem.id} / レッスンID: {problem.lesson_id}</p>
+            <p>{a.question_text}</p>
+            <p>宿題ID: {a.id} / レッスンID: {a.lesson_id}</p>
           </li>
         ))}
       </ul>

--- a/frontend/src/pages/StudentDashboard.tsx
+++ b/frontend/src/pages/StudentDashboard.tsx
@@ -15,7 +15,7 @@ interface MaterialProgress {
 }
 
 interface ProgressData {
-  total_problems: number;
+  total_assignments: number;
   correct: number;
   incorrect: number;
   unsubmitted: number;

--- a/frontend/src/pages/SubmissionHistory.tsx
+++ b/frontend/src/pages/SubmissionHistory.tsx
@@ -3,9 +3,9 @@ import { useAuth } from "../context/AuthContext";
 
 type Submission = {
   id: number;
-  problem_id: number;
-  result: string;
-  output: string;
+  assignment_id: number;
+  is_correct: number;
+  feedback: string;
   submitted_at: string;
 };
 
@@ -40,12 +40,12 @@ const SubmissionHistory: React.FC = () => {
           {submissions.map((s) => (
             <li key={s.id} style={{ marginBottom: "1.5rem" }}>
               <p><strong>提出ID:</strong> {s.id}</p>
-              <p><strong>問題ID:</strong> {s.problem_id}</p>
-              <p><strong>結果:</strong> {s.result}</p>
+              <p><strong>宿題ID:</strong> {s.assignment_id}</p>
+              <p><strong>結果:</strong> {s.is_correct ? "AC" : "WA"}</p>
               <p><strong>提出時刻:</strong> {new Date(s.submitted_at).toLocaleString()}</p>
               <details>
                 <summary>出力を表示</summary>
-                <pre>{s.output}</pre>
+                <pre>{s.feedback}</pre>
               </details>
               <hr />
             </li>


### PR DESCRIPTION
## Summary
- drop deprecated problem table and update SQLite schema
- unify API endpoints to use assignments
- adjust test case and submission handling
- update admin lesson view for assignment creation
- update front-end pages to operate on assignments

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b492f4190832f87be861661b70e80