### PR TITLE
Add progress APIs and admin tables

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -444,5 +444,29 @@ if ($path === '/api/progress' && $method === 'GET') {
     ]);
 }
 
+if ($path === '/api/user_progress' && $method === 'GET') {
+    $stmt = $pdo->query("SELECT u.id, u.username, COUNT(s.id) AS submissions, SUM(CASE WHEN s.result = 'AC' THEN 1 ELSE 0 END) AS correct FROM user u LEFT JOIN submission s ON u.id = s.user_id GROUP BY u.id, u.username");
+    $res = [];
+    foreach ($stmt as $row) {
+        $sub = (int)$row['submissions'];
+        $correct = (int)$row['correct'];
+        $accuracy = $sub ? round($correct / $sub * 100, 2) : 0;
+        $res[] = [
+            'user_id' => (int)$row['id'],
+            'username' => $row['username'],
+            'submissions' => $sub,
+            'correct' => $correct,
+            'accuracy' => $accuracy
+        ];
+    }
+    json_response($res);
+}
+
+if ($path === '/api/unsubmitted' && $method === 'GET') {
+    $stmt = $pdo->query('SELECT id, username FROM user WHERE id NOT IN (SELECT DISTINCT user_id FROM submission)');
+    $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    json_response($users);
+}
+
 json_response(['error' => 'Not found'], 404);
 ?>

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { PieChart, Pie, Cell, Tooltip, BarChart, Bar, XAxis, YAxis, CartesianGrid, Legend } from "recharts";
+import { useAuth } from "../context/AuthContext";
 
 interface DailyCount {
   date: string;
@@ -22,13 +23,35 @@ interface ProgressData {
   material_progress: MaterialProgress[];
 }
 
+interface UserProgress {
+  user_id: number;
+  username: string;
+  submissions: number;
+  correct: number;
+  accuracy: number;
+}
+
+interface UnsubmittedUser {
+  id: number;
+  username: string;
+}
+
 const AdminDashboard: React.FC = () => {
+  const { authFetch } = useAuth();
   const [data, setData] = useState<ProgressData | null>(null);
+  const [userProgress, setUserProgress] = useState<UserProgress[]>([]);
+  const [unsubmittedUsers, setUnsubmittedUsers] = useState<UnsubmittedUser[]>([]);
 
   useEffect(() => {
-    fetch("http://localhost:5050/api/progress")
+    authFetch("http://localhost:5050/api/progress")
       .then((res) => res.json())
       .then((d) => setData(d));
+    authFetch("http://localhost:5050/api/user_progress")
+      .then((res) => res.json())
+      .then((d) => setUserProgress(d));
+    authFetch("http://localhost:5050/api/unsubmitted")
+      .then((res) => res.json())
+      .then((d) => setUnsubmittedUsers(d));
   }, []);
 
   if (!data) return <p>読み込み中...</p>;
@@ -84,6 +107,46 @@ const AdminDashboard: React.FC = () => {
           </li>
         ))}
       </ul>
+
+      <h2>成績一覧</h2>
+      <table border="1" cellPadding="4" style={{ borderCollapse: "collapse", marginBottom: "1rem" }}>
+        <thead>
+          <tr>
+            <th>ユーザー名</th>
+            <th>提出数</th>
+            <th>正解数</th>
+            <th>正解率(%)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {userProgress.map((u) => (
+            <tr key={u.user_id}>
+              <td>{u.username}</td>
+              <td>{u.submissions}</td>
+              <td>{u.correct}</td>
+              <td>{u.accuracy}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2>未提出者一覧</h2>
+      <table border="1" cellPadding="4" style={{ borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            <th>ユーザーID</th>
+            <th>ユーザー名</th>
+          </tr>
+        </thead>
+        <tbody>
+          {unsubmittedUsers.map((u) => (
+            <tr key={u.id}>
+              <td>{u.id}</td>
+              <td>{u.username}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- expose `/api/user_progress` and `/api/unsubmitted` from the PHP backend
- show user progress and unsubmitted users in Admin dashboard

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b493f0c40832f948af31f31bf3b03