### PR TITLE
Add password reset page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import AdminDashboard from "./pages/AdminDashboard";
 import AssignmentList from "./pages/AssignmentList";
 import AdminCreateAssignment from "./pages/AdminCreateAssignment";
 import ChangePassword from "./pages/ChangePassword";
+import ResetPassword from "./pages/ResetPassword";
 
 function App() {
   return (
@@ -27,6 +28,7 @@ function App() {
         <Route path="/admin/assignments/create" element={<AdminCreateAssignment />} />
         <Route path="/login" element={<Login />} />
         <Route path="/change-password" element={<ChangePassword />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
         <Route path="/admin/materials" element={<AdminMaterialList />} />
         <Route path="/admin/materials/:materialId/lessons" element={<AdminLessonList />} />
         <Route path="/admin/problems/create" element={<AdminCreateProblem />} />

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { useAuth } from "../context/AuthContext";
+
+const ResetPassword: React.FC = () => {
+  const { authFetch } = useAuth();
+  const [userId, setUserId] = useState("");
+  const [newPass, setNewPass] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = () => {
+    setMessage("");
+    setError("");
+    authFetch("http://localhost:5050/api/reset_password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        user_id: Number(userId),
+        new_password: newPass,
+      }),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("reset failed");
+        return res.json();
+      })
+      .then(() => {
+        setMessage("パスワードをリセットしました");
+        setUserId("");
+        setNewPass("");
+      })
+      .catch(() => setError("リセットに失敗しました"));
+  };
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>パスワードリセット</h1>
+      {message && <p>{message}</p>}
+      {error && <p style={{ color: "red" }}>{error}</p>}
+      <div style={{ marginBottom: "1rem" }}>
+        <label>ユーザーID：</label>
+        <input
+          type="number"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+        />
+      </div>
+      <div style={{ marginBottom: "1rem" }}>
+        <label>新しいパスワード：</label>
+        <input
+          type="password"
+          value={newPass}
+          onChange={(e) => setNewPass(e.target.value)}
+        />
+      </div>
+      <button onClick={handleSubmit}>リセット</button>
+    </div>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
## Summary
- add ResetPassword page to call `/api/reset_password`
- connect the page via `/reset-password` route

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b4940f384832faeeef3a294f7590f