### PR TITLE
Add admin problem list route

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -219,6 +219,35 @@ if ($path === '/api/problems' && $method === 'POST') {
     json_response(['message' => 'Problem created', 'problem_id' => $pdo->lastInsertId()], 201);
 }
 
+if ($path === '/api/problems/by_lesson' && $method === 'GET') {
+    $lesson_id = $_GET['lesson_id'] ?? null;
+    if (!$lesson_id) json_response(['error' => 'lesson_id required'], 400);
+    $stmt = $pdo->prepare('SELECT id, lesson_id, title, markdown, created_at FROM problem WHERE lesson_id = ?');
+    $stmt->execute([$lesson_id]);
+    json_response($stmt->fetchAll(PDO::FETCH_ASSOC));
+}
+
+if (preg_match('#^/api/problems/(\d+)$#', $path, $m) && $method === 'PUT') {
+    $id = $m[1];
+    $data = json_decode(file_get_contents('php://input'), true);
+    if (!$data) json_response(['error' => 'invalid json'], 400);
+    $stmt = $pdo->prepare('UPDATE problem SET lesson_id = COALESCE(?, lesson_id), title = COALESCE(?, title), markdown = COALESCE(?, markdown) WHERE id = ?');
+    $stmt->execute([
+        $data['lesson_id'] ?? null,
+        $data['title'] ?? null,
+        $data['markdown'] ?? null,
+        $id
+    ]);
+    json_response(['message' => 'Problem updated']);
+}
+
+if (preg_match('#^/api/problems/(\d+)$#', $path, $m) && $method === 'DELETE') {
+    $id = $m[1];
+    $stmt = $pdo->prepare('DELETE FROM problem WHERE id = ?');
+    $stmt->execute([$id]);
+    json_response(['message' => 'Problem deleted']);
+}
+
 if ($path === '/api/assignments' && $method === 'GET') {
     $stmt = $pdo->query('SELECT id, lesson_id, title, description, question_text, input_example, file_path, created_at FROM assignment');
     json_response($stmt->fetchAll(PDO::FETCH_ASSOC));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import AdminDashboard from "./pages/AdminDashboard";
 import AssignmentList from "./pages/AssignmentList";
 import AdminCreateAssignment from "./pages/AdminCreateAssignment";
 import ChangePassword from "./pages/ChangePassword";
+import AdminProblemList from "./pages/AdminProblemList";
 
 function App() {
   return (
@@ -29,6 +30,7 @@ function App() {
         <Route path="/change-password" element={<ChangePassword />} />
         <Route path="/admin/materials" element={<AdminMaterialList />} />
         <Route path="/admin/materials/:materialId/lessons" element={<AdminLessonList />} />
+        <Route path="/admin/lessons/:lessonId/problems" element={<AdminProblemList />} />
         <Route path="/admin/problems/create" element={<AdminCreateProblem />} />
         <Route path="/admin/users/register" element={<AdminRegisterUser />} />
       </Routes>

--- a/frontend/src/pages/AdminProblemList.tsx
+++ b/frontend/src/pages/AdminProblemList.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+interface Problem {
+  id: number;
+  lesson_id: number;
+  title: string;
+  markdown: string;
+}
+
+const AdminProblemList: React.FC = () => {
+  const { lessonId } = useParams<{ lessonId: string }>();
+  const { authFetch } = useAuth();
+  const [problems, setProblems] = useState<Problem[]>([]);
+
+  useEffect(() => {
+    if (!lessonId) return;
+    authFetch(
+      `http://localhost:5050/api/problems/by_lesson?lesson_id=${lessonId}`
+    )
+      .then((res) => res.json())
+      .then((data) => setProblems(data));
+  }, [lessonId]);
+
+  const refresh = () => {
+    fetch(`http://localhost:5050/api/problems/by_lesson?lesson_id=${lessonId}`)
+      .then((res) => res.json())
+      .then((data) => setProblems(data));
+  };
+
+  const handleEdit = (p: Problem) => {
+    const title = prompt("新しいタイトル", p.title);
+    if (title === null) return;
+    const markdown = prompt("問題文", p.markdown ?? "") ?? p.markdown;
+    fetch(`http://localhost:5050/api/problems/${p.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        lesson_id: Number(lessonId),
+        title,
+        markdown,
+      }),
+    }).then(refresh);
+  };
+
+  const handleDelete = (id: number) => {
+    if (!window.confirm("削除しますか？")) return;
+    fetch(`http://localhost:5050/api/problems/${id}`, { method: "DELETE" }).then(
+      refresh
+    );
+  };
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>問題一覧</h1>
+      <ul>
+        {problems.map((p) => (
+          <li key={p.id}>
+            {p.title}
+            <button onClick={() => handleEdit(p)} style={{ marginLeft: "0.5rem" }}>
+              編集
+            </button>
+            <button onClick={() => handleDelete(p.id)} style={{ marginLeft: "0.5rem" }}>
+              削除
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AdminProblemList;


### PR DESCRIPTION
## Summary
- add admin lesson problem management page
- support CRUD endpoints for problems in backend API
- hook up `/admin/lessons/:lessonId/problems` route

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b4941da28832f97e2663de05e02b7