### PR TITLE
Add Dockerfile for frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,9 @@ services:
     command: php -S 0.0.0.0:5050 index.php
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
     ports:
       - "3000:3000"
     volumes:
       - ./frontend:/app
-    command: npm start

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfile for the React frontend
- use the Dockerfile via `docker-compose.yml`

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b49469160832fa80e9e64d36f7194