### PR TITLE
Improve code execution security

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -16,4 +16,9 @@
    docker run -p 5050:5050 -v $(pwd):/app programmingschool-backend
    ```
 
+### 安全なコード実行
+
+提出された Python コードは `timeout` を用いた隔離環境で実行されます。
+`/usr/bin/python3 -I -S` に限定し、5 秒を超える処理は強制終了されます。
+
 API は `http://localhost:5050/api/...` で利用できます。

--- a/backend/index.php
+++ b/backend/index.php
@@ -334,7 +334,9 @@ if ($path === '/api/submit' && $method === 'POST') {
     foreach ($cases as $case) {
         $tmp = tempnam(sys_get_temp_dir(), 'code');
         file_put_contents($tmp, $data['code']);
-        $cmd = 'python3 ' . escapeshellarg($tmp);
+        // Use isolated Python execution with a timeout to mitigate security risks
+        $safe_python = '/usr/bin/python3';
+        $cmd = 'timeout 5s ' . escapeshellcmd($safe_python) . ' -I -S ' . escapeshellarg($tmp);
         $result = [];
         $ret = null;
         $input = $case['input'];


### PR DESCRIPTION
## Summary
- execute submitted code with `timeout` and isolated Python
- document isolated Python execution in backend docs

## Testing
- `npm test --prefix frontend --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `php -l backend/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b49498420832f87eb9f77de9a38c7