### PR TITLE
Implement problem table and admin protections

### DIFF
--- a/backend/create_tables.php
+++ b/backend/create_tables.php
@@ -23,6 +23,15 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS lesson (
     FOREIGN KEY(material_id) REFERENCES material(id) ON DELETE CASCADE
 );");
 
+$pdo->exec("CREATE TABLE IF NOT EXISTS problem (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    lesson_id INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    markdown TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(lesson_id) REFERENCES lesson(id) ON DELETE CASCADE
+);");
+
 $pdo->exec("CREATE TABLE IF NOT EXISTS assignment (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     lesson_id INTEGER NOT NULL,

--- a/frontend/src/pages/AdminCreateTestCase.tsx
+++ b/frontend/src/pages/AdminCreateTestCase.tsx
@@ -7,7 +7,6 @@ interface Testcase {
   input: string;
   expected_output: string;
   comment: string;
-  comment?: string;
 }
 
 const AdminCreateTestCase: React.FC = () => {
@@ -29,8 +28,6 @@ const AdminCreateTestCase: React.FC = () => {
           }))
         )
       );
-  }, [problemId]);
-      .then((data) => setTestcases(data));
   }, [assignmentId]);
 
   const handleAdd = () => {

--- a/frontend/src/pages/AdminProblemList.tsx
+++ b/frontend/src/pages/AdminProblemList.tsx
@@ -24,7 +24,9 @@ const AdminProblemList: React.FC = () => {
   }, [lessonId]);
 
   const refresh = () => {
-    fetch(`http://localhost:5050/api/problems/by_lesson?lesson_id=${lessonId}`)
+    authFetch(
+      `http://localhost:5050/api/problems/by_lesson?lesson_id=${lessonId}`
+    )
       .then((res) => res.json())
       .then((data) => setProblems(data));
   };
@@ -33,7 +35,7 @@ const AdminProblemList: React.FC = () => {
     const title = prompt("新しいタイトル", p.title);
     if (title === null) return;
     const markdown = prompt("問題文", p.markdown ?? "") ?? p.markdown;
-    fetch(`http://localhost:5050/api/problems/${p.id}`, {
+    authFetch(`http://localhost:5050/api/problems/${p.id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -46,7 +48,7 @@ const AdminProblemList: React.FC = () => {
 
   const handleDelete = (id: number) => {
     if (!window.confirm("削除しますか？")) return;
-    fetch(`http://localhost:5050/api/problems/${id}`, { method: "DELETE" }).then(
+    authFetch(`http://localhost:5050/api/problems/${id}`, { method: "DELETE" }).then(
       refresh
     );
   };


### PR DESCRIPTION
## Summary
- add `problem` table and migration
- secure modification endpoints with `is_admin` checks
- implement `/api/problems` endpoints
- clean up `/api/testcases` logic
- fix admin frontend calls and bug in test case page

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b7c239d70832fa945e20c66451e9e