### PR TITLE
Restrict user registration to admins

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -62,7 +62,7 @@ function require_admin() {
     }
 }
 
-$public_paths = ['/api/login', '/api/register'];
+$public_paths = ['/api/login'];
 if (!in_array($path, $public_paths)) {
     require_auth();
 }
@@ -74,6 +74,8 @@ function json_response($data, $status = 200) {
 }
 
 if ($path === '/api/register' && $method === 'POST') {
+    require_auth();
+    require_admin();
     $data = json_decode(file_get_contents('php://input'), true);
     if (!isset($data['username']) || !isset($data['password'])) {
         json_response(['error' => 'username and password required'], 400);

--- a/frontend/src/pages/AdminRegisterUser.tsx
+++ b/frontend/src/pages/AdminRegisterUser.tsx
@@ -6,7 +6,10 @@ const AdminRegisterUser: React.FC = () => {
   const [password, setPassword] = useState("");
   const [isAdmin, setIsAdmin] = useState(false);
   const [message, setMessage] = useState("");
-  const { authFetch } = useAuth();
+  const { user, authFetch } = useAuth();
+
+  if (!user) return <p>ログインしてください</p>;
+  if (!user.is_admin) return <p>権限がありません</p>;
 
   const handleRegister = () => {
     authFetch("http://localhost:5050/api/register", {


### PR DESCRIPTION
## Summary
- require authentication and admin rights for `/api/register`
- remove `/api/register` from public paths in the PHP backend
- hide the admin registration page from non-admins

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b908cdf20832fb73c7a6abdf1fb11