### PR TITLE
Add description column to materials

### DIFF
--- a/backend/create_tables.php
+++ b/backend/create_tables.php
@@ -12,8 +12,20 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS user (
 
 $pdo->exec("CREATE TABLE IF NOT EXISTS material (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    title TEXT NOT NULL
+    title TEXT NOT NULL,
+    description TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
 );");
+
+// マイグレーション：既存DBに description, created_at カラムを追加
+$cols = $pdo->query('PRAGMA table_info(material)')->fetchAll(PDO::FETCH_ASSOC);
+$colNames = array_column($cols, 'name');
+if (!in_array('description', $colNames)) {
+    $pdo->exec('ALTER TABLE material ADD COLUMN description TEXT');
+}
+if (!in_array('created_at', $colNames)) {
+    $pdo->exec("ALTER TABLE material ADD COLUMN created_at TEXT DEFAULT CURRENT_TIMESTAMP");
+}
 
 $pdo->exec("CREATE TABLE IF NOT EXISTS lesson (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/backend/index.php
+++ b/backend/index.php
@@ -145,7 +145,7 @@ if ($path === '/api/reset_password' && $method === 'POST') {
 }
 
 if ($path === '/api/materials' && $method === 'GET') {
-    $stmt = $pdo->query('SELECT id, title FROM material');
+    $stmt = $pdo->query('SELECT id, title, description, created_at FROM material');
     json_response($stmt->fetchAll(PDO::FETCH_ASSOC));
 }
 
@@ -153,8 +153,11 @@ if ($path === '/api/materials' && $method === 'POST') {
     require_admin();
     $data = json_decode(file_get_contents('php://input'), true);
     if (!isset($data['title'])) json_response(['error' => 'title required'], 400);
-    $stmt = $pdo->prepare('INSERT INTO material (title) VALUES (?)');
-    $stmt->execute([$data['title']]);
+    $stmt = $pdo->prepare('INSERT INTO material (title, description) VALUES (?, ?)');
+    $stmt->execute([
+        $data['title'],
+        $data['description'] ?? null
+    ]);
     json_response(['message' => 'Created', 'material_id' => $pdo->lastInsertId()], 201);
 }
 
@@ -163,8 +166,12 @@ if (preg_match('#^/api/materials/(\d+)$#', $path, $m) && $method === 'PUT') {
     $material_id = $m[1];
     $data = json_decode(file_get_contents('php://input'), true);
     if (!isset($data['title'])) json_response(['error' => 'title required'], 400);
-    $stmt = $pdo->prepare('UPDATE material SET title = ? WHERE id = ?');
-    $stmt->execute([$data['title'], $material_id]);
+    $stmt = $pdo->prepare('UPDATE material SET title = ?, description = ? WHERE id = ?');
+    $stmt->execute([
+        $data['title'],
+        $data['description'] ?? null,
+        $material_id
+    ]);
     json_response(['message' => 'Updated']);
 }
 

--- a/frontend/src/pages/AdminMaterialList.tsx
+++ b/frontend/src/pages/AdminMaterialList.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../context/AuthContext";
 const AdminMaterialList: React.FC = () => {
   const [materials, setMaterials] = useState([]);
   const [newTitle, setNewTitle] = useState("");
+  const [newDescription, setNewDescription] = useState("");
   const navigate = useNavigate();
   const { authFetch } = useAuth();
 
@@ -18,11 +19,12 @@ const AdminMaterialList: React.FC = () => {
     authFetch("http://localhost:5050/api/materials", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: newTitle }),
+      body: JSON.stringify({ title: newTitle, description: newDescription }),
     })
       .then((res) => res.json())
       .then(() => {
         setNewTitle("");
+        setNewDescription("");
         return authFetch("http://localhost:5050/api/materials");
       })
       .then((res) => res.json())
@@ -35,13 +37,19 @@ const AdminMaterialList: React.FC = () => {
       .then((data) => setMaterials(data));
   };
 
-  const handleEdit = (id: number, currentTitle: string) => {
+  const handleEdit = (
+    id: number,
+    currentTitle: string,
+    currentDescription: string | null
+  ) => {
     const title = prompt("新しいタイトル", currentTitle);
-    if (!title) return;
+    if (title === null) return;
+    const description = prompt("説明", currentDescription ?? "");
+    if (description === null) return;
     fetch(`http://localhost:5050/api/materials/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title }),
+      body: JSON.stringify({ title, description }),
     }).then(refresh);
   };
 
@@ -61,6 +69,13 @@ const AdminMaterialList: React.FC = () => {
         value={newTitle}
         onChange={(e) => setNewTitle(e.target.value)}
       />
+      <input
+        type="text"
+        placeholder="説明"
+        value={newDescription}
+        onChange={(e) => setNewDescription(e.target.value)}
+        style={{ marginLeft: "0.5rem" }}
+      />
       <button onClick={handleCreate}>教材を追加</button>
       <ul>
         {materials.map((m: any) => (
@@ -68,7 +83,11 @@ const AdminMaterialList: React.FC = () => {
             <button onClick={() => navigate(`/admin/materials/${m.id}/lessons`)}>
               {m.title}
             </button>
-            <button onClick={() => handleEdit(m.id, m.title)} style={{ marginLeft: "0.5rem" }}>
+            <span style={{ marginLeft: "0.5rem" }}>{m.description}</span>
+            <button
+              onClick={() => handleEdit(m.id, m.title, m.description)}
+              style={{ marginLeft: "0.5rem" }}
+            >
               編集
             </button>
             <button onClick={() => handleDelete(m.id)} style={{ marginLeft: "0.5rem" }}>


### PR DESCRIPTION
## Summary
- add `description` and `created_at` columns for material creation
- support new columns in `/api/materials` endpoints
- update admin material page to edit and display description
- perform db migration for existing materials

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9957cc98832f95d922b53ff1ddcc