### PR TITLE
Add lesson progress tracking

### DIFF
--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -14,6 +14,13 @@ interface MaterialProgress {
   total: number;
 }
 
+interface LessonProgress {
+  lesson_id: number;
+  title: string;
+  completed: number;
+  total: number;
+}
+
 interface ProgressData {
   total_assignments: number;
   correct: number;
@@ -21,6 +28,7 @@ interface ProgressData {
   unsubmitted: number;
   daily_counts: DailyCount[];
   material_progress: MaterialProgress[];
+  lesson_progress: LessonProgress[];
 }
 
 interface UserProgress {
@@ -103,6 +111,27 @@ const AdminDashboard: React.FC = () => {
             </div>
             <small>
               {m.completed}/{m.total}
+            </small>
+          </li>
+        ))}
+      </ul>
+
+      <h2>レッスン別進捗</h2>
+      <ul>
+        {data.lesson_progress.map((l) => (
+          <li key={l.lesson_id} style={{ marginBottom: "0.5rem" }}>
+            <div>{l.title}</div>
+            <div style={{ background: "#eee", width: "100%", height: "20px" }}>
+              <div
+                style={{
+                  width: `${l.total ? (l.completed / l.total) * 100 : 0}%`,
+                  background: "#82ca9d",
+                  height: "100%",
+                }}
+              />
+            </div>
+            <small>
+              {l.completed}/{l.total}
             </small>
           </li>
         ))}

--- a/frontend/src/pages/StudentDashboard.tsx
+++ b/frontend/src/pages/StudentDashboard.tsx
@@ -14,6 +14,13 @@ interface MaterialProgress {
   total: number;
 }
 
+interface LessonProgress {
+  lesson_id: number;
+  title: string;
+  completed: number;
+  total: number;
+}
+
 interface ProgressData {
   total_assignments: number;
   correct: number;
@@ -21,6 +28,7 @@ interface ProgressData {
   unsubmitted: number;
   daily_counts: DailyCount[];
   material_progress: MaterialProgress[];
+  lesson_progress: LessonProgress[];
 }
 
 const StudentDashboard: React.FC = () => {
@@ -84,6 +92,27 @@ const StudentDashboard: React.FC = () => {
             </div>
             <small>
               {m.completed}/{m.total}
+            </small>
+          </li>
+        ))}
+      </ul>
+
+      <h2>レッスン別進捗</h2>
+      <ul>
+        {data.lesson_progress.map((l) => (
+          <li key={l.lesson_id} style={{ marginBottom: "0.5rem" }}>
+            <div>{l.title}</div>
+            <div style={{ background: "#eee", width: "100%", height: "20px" }}>
+              <div
+                style={{
+                  width: `${l.total ? (l.completed / l.total) * 100 : 0}%`,
+                  background: "#82ca9d",
+                  height: "100%",
+                }}
+              />
+            </div>
+            <small>
+              {l.completed}/{l.total}
             </small>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- calculate progress for each lesson in `/api/progress`
- return new `lesson_progress` array in progress API
- display lesson progress bars in student and admin dashboards

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4b02e714832f8e86a137d95eec91