### PR TITLE
Add caching for /api/progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,8 @@ docker-compose up --build
 
 学習者用 `/dashboard` と管理者用 `/admin/dashboard` では Recharts を利用した
 円グラフ・棒グラフ・進捗バーで提出状況を確認できます。
+
+### API キャッシュ
+
+`/api/progress` の集計結果は 60 秒間キャッシュされます。`force=1` を
+クエリに付与するとキャッシュを無視して再計算できます。


### PR DESCRIPTION
## Summary
- add simple cache utilities using APCu or temp files
- cache progress API results for 60 seconds and allow manual invalidation
- document API cache behaviour

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4ee1f580832f93d79f0006a9ec4e